### PR TITLE
Add DP Synthetic Data Leakage Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ list of differential-privacy related repositories (and a bit more)
 - [diffpriv  - Easy differential privacy in R](http://www.bipr.net/diffpriv/)
 - [DP-XGBoost - Private Machine Learning at Scale](https://github.com/sarus-tech/dp-xgboost)
 - [Qrlew - The SQL-to-SQL Differential Privacy layer](https://qrlew.github.io/)
+- [Breaking Privacy in Real-World Differentially Private Synthetic Data](https://amanpriyanshu.github.io/SynthLeak/)
 
 ## Learn
 - [The Algorithmic Foundations of Differential Privacy - Book](https://www.cis.upenn.edu/~aaroth/Papers/privacybook.pdf)


### PR DESCRIPTION
**Description:**
Adding a technical analysis demonstrating privacy vulnerabilities in differentially private synthetic data generation.

```markdown
- [Breaking Privacy in Real-World Differentially Private Synthetic Data](https://amanpriyanshu.github.io/SynthLeak/)
```

**Files changed:** README.md