### PR TITLE
Add AWS Labs Fast Differential Privacy Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ list of differential-privacy related repositories (and a bit more)
 - [DP-XGBoost - Private Machine Learning at Scale](https://github.com/sarus-tech/dp-xgboost)
 - [Qrlew - The SQL-to-SQL Differential Privacy layer](https://qrlew.github.io/)
 - [Breaking Privacy in Real-World Differentially Private Synthetic Data](https://amanpriyanshu.github.io/SynthLeak/)
+- [Fast-Differential-Privacy - A Faster way of training PyTorch models with Differential Privacy ](https://github.com/awslabs/fast-differential-privacy)
 
 ## Learn
 - [The Algorithmic Foundations of Differential Privacy - Book](https://www.cis.upenn.edu/~aaroth/Papers/privacybook.pdf)


### PR DESCRIPTION
Description: Added a new library from AWS that lets users train PyTorch Models with Differential Privacy with Claims of it being faster in  training time and with lesser memory costs.

Library Link: https://github.com/awslabs/fast-differential-privacy

Files Changed: README.md